### PR TITLE
fix(tests): mock i18n context as store to resolve subscribe errors

### DIFF
--- a/src/tests/components/AvatarSelection.test.js
+++ b/src/tests/components/AvatarSelection.test.js
@@ -53,15 +53,24 @@ vi.mock('$lib/stores', () => {
 // Mock context API with proper function syntax to avoid type errors
 vi.mock('svelte', async () => {
 	const actual = await vi.importActual('svelte');
+	const { writable } = await vi.importActual('svelte/store');
+
+	const mockI18nStore = writable({
+		t: (key) => key
+	});
+
 	return {
 		...actual,
-		getContext: () => ({
-			t: function (key) {
-				return key;
+		getContext: (key) => {
+			if (key === 'i18n') {
+				return mockI18nStore;
 			}
-		})
+			return {};
+		}
 	};
 });
+
+
 
 // Create a reference to the mock settings for tests to use
 const mockSettings = vi.mocked(await import('$lib/stores')).settings;

--- a/src/tests/components/responsive.test.js
+++ b/src/tests/components/responsive.test.js
@@ -9,7 +9,7 @@ vi.mock('$lib/stores', () => {
 	const mockSettings = {
 		subscribe: vi.fn((cb) => {
 			cb({});
-			return () => {};
+			return () => { };
 		}),
 		update: vi.fn((cb) => {
 			const updated = cb({});
@@ -21,26 +21,26 @@ vi.mock('$lib/stores', () => {
 		i18n: {
 			subscribe: vi.fn((cb) => {
 				cb({ t: (key) => key });
-				return () => {};
+				return () => { };
 			})
 		},
 		settings: mockSettings,
 		TUTOR_NAME: {
 			subscribe: vi.fn((cb) => {
 				cb('OpenTutorAI');
-				return () => {};
+				return () => { };
 			})
 		},
 		mobile: {
 			subscribe: vi.fn((cb) => {
 				cb(false);
-				return () => {};
+				return () => { };
 			})
 		},
 		config: {
 			subscribe: vi.fn((cb) => {
 				cb({});
-				return () => {};
+				return () => { };
 			})
 		}
 	};
@@ -49,13 +49,25 @@ vi.mock('$lib/stores', () => {
 // Mock context API
 vi.mock('svelte', async () => {
 	const actual = await vi.importActual('svelte');
+	const { writable } = await vi.importActual('svelte/store');
+
+	const mockI18nStore = writable({
+		t: (key) => key
+	});
+
 	return {
 		...actual,
-		getContext: () => ({
-			t: (key) => key
-		})
+		getContext: (key) => {
+			if (key === 'i18n') {
+				return mockI18nStore;
+			}
+			return {};
+		}
 	};
 });
+
+
+
 
 describe('Responsive Layout Tests', () => {
 	// Store original window dimensions


### PR DESCRIPTION
## Changelog Entry

### Description

This PR resolves test failures caused by incorrect usage of the `i18n` context in the `src\tests\components\AvatarSelection.test.js` and `src\tests\components\responsive.test.js` component test suites. The i18n context was not a valid Svelte store, causing errors during component instantiation in test environments.

### Added

- Mock implementation of the `i18n` context with a minimal `subscribe` method for use in tests.

### Changed

- Updated `AvatarSelection.test.js` and `responsive.test.js` to provide a proper mocked `i18n` store.


### Fixed

- ✅ `'i18n' is not a store with a 'subscribe' method` error across multiple test cases.


### Additional Information

- This fix ensures all unit tests pass successfully by aligning the test environment with the actual runtime Svelte component expectations.
- Related to the discussion around mocking context-based stores in component tests.

### Screenshots

When we run 'npm run test':

before:

![image](https://github.com/user-attachments/assets/e6193288-efa9-4ba0-baa8-b2c76e990c2c)

After:

![image](https://github.com/user-attachments/assets/6f4b13cf-2b20-4a98-88a7-896b85028635)


check was successful in my branch:
![image](https://github.com/user-attachments/assets/76df34e8-c241-4bf6-a7ba-40a93f4e5630)

