### PR TITLE
Fix Authentication Mode Mismatch

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -20,7 +20,7 @@
 
 	let loaded = false;
 	let showForgotPassword = false;
-	let mode = $config?.features.enable_ldap ? 'ldap' : 'login'; // Changed default to login
+	let mode = $config?.features.enable_ldap ? 'ldap' : 'signin'; // Changed default to signin
 	let firstName = '';
 	let lastName = '';
 	let email = '';


### PR DESCRIPTION
## Description
Fixes the authentication issue where direct sign-in attempts failed due to a mode mismatch between frontend ('login') and backend ('signin').

## Changes
- Changed default mode from 'login' to 'signin' in `src/routes/auth/+page.svelte`

## Testing
- [x] Direct sign-in now works correctly
- [x] No need to switch modes for successful authentication