### PR TITLE
Admin user creation dropdown appears light in dark mode

### DIFF
--- a/src/lib/components/admin/Users/UserList/AddUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/AddUserModal.svelte
@@ -181,15 +181,15 @@
 
 								<div class="flex-1">
 									<select
-										class="w-full capitalize rounded-lg text-sm bg-transparent dark:disabled:text-gray-500 outline-hidden"
+										class="w-full capitalize rounded-lg text-sm bg-transparent dark:bg-gray-800 dark:text-white dark:disabled:text-gray-500 outline-hidden"
 										bind:value={_user.role}
 										placeholder={$i18n.t('Enter Your Role')}
 										required
 									>
-										<option value="user"> {$i18n.t('student')} </option>
-										<option value="teacher"> {$i18n.t('teacher')} </option>
-										<option value="parent"> {$i18n.t('parent')} </option>
-										<option value="admin"> {$i18n.t('admin')} </option>
+										<option class="dark:bg-gray-800" value="user"> {$i18n.t('student')} </option>
+										<option class="dark:bg-gray-800" value="teacher"> {$i18n.t('teacher')} </option>
+										<option class="dark:bg-gray-800" value="parent"> {$i18n.t('parent')} </option>
+										<option class="dark:bg-gray-800" value="admin"> {$i18n.t('admin')} </option>
 									</select>
 								</div>
 							</div>


### PR DESCRIPTION
Description:
Fixed issue [#142](https://github.com/R2D-dev/open-tutor-ai-CE/issues/142) :  where when admin tries to create a user, the dropdown is totally light in dark mode. The dropdown now has proper dark mode styling.

Changelog Entry

Description:
Fixed issue where the role dropdown in the admin user creation form appeared with a light background when using dark mode.

Changed:
- Added dark mode background styling (dark:bg-gray-800) to the select element in the user creation modal

Fixed:
- User creation dropdown appears light in dark mode instead of matching the dark theme

Screenshots:
![image](https://github.com/user-attachments/assets/4ea84feb-a6b9-4716-a6c6-af8ee3cbf382)