### PR TITLE
fix: incorrect logo display issue

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import { browser, dev } from '$app/environment';
 
 export const APP_NAME = 'Open TutorAI';
 
-export const TUTOR_HOSTNAME = browser ? (dev ? `${location.hostname}:8080` : ``) : '';
+export const TUTOR_HOSTNAME = browser ? (dev ? `${location.hostname}:5173` : ``) : '';
 export const TUTOR_BASE_URL = browser ? (dev ? `http://${TUTOR_HOSTNAME}` : ``) : ``;
 export const TUTOR_API_BASE_URL = `${TUTOR_BASE_URL}/api/v1`;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
 			targets: [
 				{
 					src: 'node_modules/onnxruntime-web/dist/*.jsep.*',
-
 					dest: 'wasm'
 				}
 			]
@@ -41,6 +40,14 @@ export default defineConfig({
 		format: 'es'
 	},
 	server: {
+		port: 5173,
+		host: true, // This enables listening on all network interfaces
+		proxy: {
+			'/api': {
+				target: 'http://localhost:8080',
+				changeOrigin: true
+			}
+		},
 		fs: {
 			allow: ['./static/avatar', './static/classroom', './static/draco', './static/images/background.jpeg']
 		}


### PR DESCRIPTION
#### Description
This PR changes the development server port from 8080 to 5173. The change ensures all application resources (static assets) are correctly served.
* Fixed 404 errors for API endpoints when attempting to use port 5173
* Resolved incorrect logo display issue where WebUI logo was showing instead of Open Tutor logo
#### Notes for Reviewers
- Make sure to restart your development server after pulling these changes
- Some environment setups might require additional configuration if port 5173 is already in use