### PR TITLE
fix: apply #235's spacing fix to .markdown-prose-xs too

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -59,7 +59,14 @@ math {
 }
 
 .markdown-prose-xs {
-	@apply text-xs prose dark:prose-invert prose-blockquote:border-s-gray-100 prose-blockquote:dark:border-gray-800 prose-blockquote:border-s-2 prose-blockquote:not-italic prose-blockquote:font-normal  prose-headings:font-semibold prose-hr:my-0  prose-hr:border-gray-100 prose-hr:dark:border-gray-800 prose-p:my-0 prose-img:my-1 prose-headings:my-1 prose-pre:my-0 prose-table:my-0 prose-blockquote:my-0 prose-ul:-my-0 prose-ol:-my-0 prose-li:-my-0 whitespace-pre-line;
+    @apply text-xs prose dark:prose-invert max-w-none
+    prose-blockquote:border-s-gray-100 prose-blockquote:dark:border-gray-800
+    prose-blockquote:border-s-2 prose-blockquote:not-italic prose-blockquote:font-normal
+    prose-headings:font-semibold
+    prose-hr:my-0 prose-hr:border-gray-100 prose-hr:dark:border-gray-800
+    prose-p:my-1 prose-img:my-1 prose-headings:my-2 prose-pre:my-2
+    prose-table:my-2 prose-blockquote:my-2
+    prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5;
 }
 
 .markdown a {


### PR DESCRIPTION

  ## What this does
  While looking into issue #22, I noticed that `.markdown-prose-xs` (used in
  `FloatingButtons.svelte` for the "explain selected text" popup) has the same
  spacing bugs that `.markdown-prose` had before PR #235 fixed it — negative
  margins on lists/list items, zero margins on paragraphs/headings/code blocks,
  no `max-w-none`, and a `whitespace-pre-line` rule that fights with `marked`'s
  HTML output.

  This PR applies the same corrected spacing to `.markdown-prose-xs` so both
  prose variants render consistently, which is part of what #22 is asking for.

  ## Changes
  - `src/app.css`: fixed `.markdown-prose-xs` spacing to match the corrected
    `.markdown-prose` from #235 (removed the negative margins and
    `whitespace-pre-line`, added `max-w-none`)

  ## Notes
  - This complements #235 rather than overlapping with it — different class,
    same root cause
  - Related to #22