### PR TITLE
fix: correct context and volume paths in docker-compose.yaml

### DIFF
--- a/devops/docker/docker-compose.yaml
+++ b/devops/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 services:
   open-tutorai:
     build:
-      context: ..
+      context: ../..
       dockerfile: devops/docker/Dockerfile.backend
     image: open-tutorai
     container_name: open-tutorai
@@ -13,9 +13,9 @@ services:
       - "8080:8080"
     working_dir: /app
     volumes:
-      - ../var:/app/var
+      - ../../var:/app/var
     env_file:
-      - ../.env
+      - ../../.env
     # Mapping syntax avoids YAML list-parsing issues with interpolation strings.
     # SECRET_KEY is validated at compose-up time: missing key = hard failure with
     # a message that includes the generation command.


### PR DESCRIPTION
## Summary

Following the README setup steps fails immediately at config time:

`env file .../devops/.env not found
`
Relative paths in `devops/docker/docker-compose.yaml` resolve relative to the
compose file's own directory (`devops/docker/`), but they were written assuming
the repo root (where the README tells you to run the command). Every path was
one level too shallow, so:

- `env_file: ../.env` → looked for `devops/.env` (the reported error)
- `context: ..` → build context was `devops/` instead of the repo root, so the
  Dockerfile's `COPY ui/`, `COPY ./requirements.txt`, and `COPY . .` would have
  failed even after the env_file was found
- `volumes: ../var` → persisted data under `devops/var/` instead of `var/`

## Changes

Bumped the three relative paths up one level so they resolve from the repo root:

| Field | Before | After |
|-------|--------|-------|
| build `context` | `..` | `../..` |
| `volumes` | `../var:/app/var` | `../../var:/app/var` |
| `env_file` | `../.env` | `../../.env` |

## Testing

`docker compose --env-file .env -f devops/docker/docker-compose.yaml config`
now resolves cleanly:
- build context → repo root
- volume source → `<repo>/var`
- `.env` loaded and `SECRET_KEY` validation passes

The exact README command now proceeds past config into the build:

```bash
docker compose --env-file .env -f devops/docker/docker-compose.yaml up --build