### PR TITLE
fix(auth): persist and return user role on signup

### DIFF
--- a/accounts/users/service.py
+++ b/accounts/users/service.py
@@ -35,6 +35,7 @@ class AccountService:
         password_plain: str,
         profile_image_url: Optional[str] = None,
         is_admin: bool = False,
+        role: str = "user",
     ) -> User:
         """Create a new user; first user is automatically admin."""
         if self.repo.get_by_email(email):
@@ -47,6 +48,7 @@ class AccountService:
             profile_image_url=profile_image_url,
             is_active=True,
             is_admin=is_admin,
+            role="admin" if is_admin else role,
         )
 
     def authenticate(self, email: str, password_plain: str) -> Optional[User]:

--- a/gateway/http/routers/auth.py
+++ b/gateway/http/routers/auth.py
@@ -62,7 +62,7 @@ def _user_payload(token: str, user: User) -> dict:
         "id": user.id,
         "email": user.email,
         "name": user.name,
-        "role": "admin" if user.is_admin else "user",
+        "role": "admin" if user.is_admin else (user.role or "user"),
         "profile_image_url": user.profile_image_url,
     }
 
@@ -74,7 +74,7 @@ async def get_session_user(current_user: User = Depends(get_current_user)):
         "id": current_user.id,
         "email": current_user.email,
         "name": current_user.name,
-        "role": "admin" if current_user.is_admin else "user",
+        "role": "admin" if current_user.is_admin else (current_user.role or "user"),
         "profile_image_url": current_user.profile_image_url,
     }
 
@@ -120,6 +120,7 @@ async def signup(
             password_plain=request.password,
             profile_image_url=request.profile_image_url,
             is_admin=is_admin,
+            role=request.role or "user",
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -154,6 +155,7 @@ async def add_user(
             password_plain=request.password,
             profile_image_url=request.profile_image_url,
             is_admin=(request.role == "admin"),
+            role=request.role or "user",
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -178,7 +180,7 @@ async def update_profile(
         "id": user.id,
         "email": user.email,
         "name": user.name,
-        "role": "admin" if user.is_admin else "user",
+        "role": "admin" if user.is_admin else (user.role or "user"),
         "profile_image_url": user.profile_image_url,
     }
 


### PR DESCRIPTION
## Problem
When a teacher (or parent) creates an account, they're redirected to the student space instead of their own. The frontend correctly sends the selected role (`teacher` / `parent` / `user`) and the redirect logic correctly maps it.. but the backend silently discarded it, so every new user ended up as `user`.

## Changes

- `accounts/users/service.py` — `create_user() `now accepts a role param and persists `"admin" if is_admin else role`.
- `gateway/http/routers/auth.py` — `signup()` and `add_user()` now pass request.role; the session payload helpers return the real user.role (with `is_admin` still overriding to `"admin"`).