### PR TITLE
fix: update avatar and classroom model paths to remove static prefix

### DIFF
--- a/ui/src/lib/components/chat/AvatarChat.svelte
+++ b/ui/src/lib/components/chat/AvatarChat.svelte
@@ -510,7 +510,7 @@
 				// Original position for avatar only view
 				avatar.position.set(-center.x, -center.y + size.y / 2, -center.z);
 			}
-			
+
 			loading = false;
 
 			// Set a more natural default pose instead of T-pose
@@ -2725,12 +2725,12 @@
 			<Spinner />
 		</div>
 	{/if}
-	
+
 	{#if scene && useClassroom}
-		<ClassroomBackground 
+		<ClassroomBackground
 			bind:this={classroomComponent}
-			{scene} 
-			{camera} 
+			{scene}
+			{camera}
 			{classroomModel}
 			boardMessage={currentMessage}
 		/>

--- a/ui/src/lib/components/chat/AvatarChat.svelte
+++ b/ui/src/lib/components/chat/AvatarChat.svelte
@@ -129,38 +129,38 @@
 		glbAnimations: {
 			// Map human-readable names to file paths
 			expression: {
-				talking_neutral: '/static/avatar/glb/expression/M_Talking_Variations_001.glb',
-				talking_happy: '/static/avatar/glb/expression/M_Talking_Variations_002.glb',
-				talking_excited: '/static/avatar/glb/expression/M_Talking_Variations_005.glb',
-				talking_thoughtful: '/static/avatar/glb/expression/M_Talking_Variations_007.glb',
-				talking_concerned: '/static/avatar/glb/expression/M_Talking_Variations_009.glb',
-				expression_smile: '/static/avatar/glb/expression/M_Standing_Expressions_001.glb',
-				expression_sad: '/static/avatar/glb/expression/M_Standing_Expressions_007.glb',
-				expression_surprise: '/static/avatar/glb/expression/M_Standing_Expressions_010.glb',
-				expression_thinking: '/static/avatar/glb/expression/M_Standing_Expressions_013.glb',
-				expression_angry: '/static/avatar/glb/expression/M_Standing_Expressions_016.glb'
+				talking_neutral: '/avatar/glb/expression/M_Talking_Variations_001.glb',
+				talking_happy: '/avatar/glb/expression/M_Talking_Variations_002.glb',
+				talking_excited: '/avatar/glb/expression/M_Talking_Variations_005.glb',
+				talking_thoughtful: '/avatar/glb/expression/M_Talking_Variations_007.glb',
+				talking_concerned: '/avatar/glb/expression/M_Talking_Variations_009.glb',
+				expression_smile: '/avatar/glb/expression/M_Standing_Expressions_001.glb',
+				expression_sad: '/avatar/glb/expression/M_Standing_Expressions_007.glb',
+				expression_surprise: '/avatar/glb/expression/M_Standing_Expressions_010.glb',
+				expression_thinking: '/avatar/glb/expression/M_Standing_Expressions_013.glb',
+				expression_angry: '/avatar/glb/expression/M_Standing_Expressions_016.glb'
 			},
 			idle: {
-				idle_normal: '/static/avatar/glb/idle/M_Standing_Idle_001.glb',
-				idle_shift_weight: '/static/avatar/glb/idle/M_Standing_Idle_Variations_001.glb',
-				idle_look_around: '/static/avatar/glb/idle/M_Standing_Idle_Variations_003.glb',
-				idle_default: '/static/avatar/glb/idle/M_Standing_Idle_Variations_008.glb',
-				idle_stretch: '/static/avatar/glb/idle/M_Standing_Idle_Variations_006.glb',
-				idle_impatient: '/static/avatar/glb/idle/M_Standing_Idle_Variations_008.glb'
+				idle_normal: '/avatar/glb/idle/M_Standing_Idle_001.glb',
+				idle_shift_weight: '/avatar/glb/idle/M_Standing_Idle_Variations_001.glb',
+				idle_look_around: '/avatar/glb/idle/M_Standing_Idle_Variations_003.glb',
+				idle_default: '/avatar/glb/idle/M_Standing_Idle_Variations_008.glb',
+				idle_stretch: '/avatar/glb/idle/M_Standing_Idle_Variations_006.glb',
+				idle_impatient: '/avatar/glb/idle/M_Standing_Idle_Variations_008.glb'
 			},
 			locomotion: {
-				walk_forward: '/static/avatar/glb/locomotion/M_Walk_001.glb',
-				walk_backward: '/static/avatar/glb/locomotion/M_Walk_Backwards_001.glb',
-				jog_forward: '/static/avatar/glb/locomotion/M_Jog_001.glb',
-				run_forward: '/static/avatar/glb/locomotion/M_Run_001.glb',
-				jump: '/static/avatar/glb/locomotion/M_Walk_Jump_001.glb',
-				crouch: '/static/avatar/glb/locomotion/M_Crouch_Walk_003.glb'
+				walk_forward: '/avatar/glb/locomotion/M_Walk_001.glb',
+				walk_backward: '/avatar/glb/locomotion/M_Walk_Backwards_001.glb',
+				jog_forward: '/avatar/glb/locomotion/M_Jog_001.glb',
+				run_forward: '/avatar/glb/locomotion/M_Run_001.glb',
+				jump: '/avatar/glb/locomotion/M_Walk_Jump_001.glb',
+				crouch: '/avatar/glb/locomotion/M_Crouch_Walk_003.glb'
 			},
 			dance: {
-				dance_casual: '/static/avatar/glb/dance/M_Dances_001.glb',
-				dance_energetic: '/static/avatar/glb/dance/M_Dances_003.glb',
-				dance_rhythmic: '/static/avatar/glb/dance/M_Dances_007.glb',
-				dance_silly: '/static/avatar/glb/dance/M_Dances_009.glb'
+				dance_casual: '/avatar/glb/dance/M_Dances_001.glb',
+				dance_energetic: '/avatar/glb/dance/M_Dances_003.glb',
+				dance_rhythmic: '/avatar/glb/dance/M_Dances_007.glb',
+				dance_silly: '/avatar/glb/dance/M_Dances_009.glb'
 			}
 		}
 	};
@@ -262,7 +262,7 @@
 
 		// Load selected avatar model from static/avatar directory
 		// This uses the ID from user preferences to load the appropriate GLB file
-		const avatarPath = `/static/avatar/${selectedAvatarId}.glb`;
+		const avatarPath = `/avatar/${selectedAvatarId}.glb`;
 		console.log(`Loading avatar from: ${avatarPath}`);
 		await loadAvatar(avatarPath);
 

--- a/ui/src/lib/components/classroom/ClassroomBackground.svelte
+++ b/ui/src/lib/components/classroom/ClassroomBackground.svelte
@@ -127,14 +127,14 @@
       const dracoLoader = new DRACOLoader();
       
       // Try to use the static draco folders if available, with fallback
-      dracoLoader.setDecoderPath('/static/draco/');
+      dracoLoader.setDecoderPath('/draco/');
       console.log("DracoLoader path set");
       
       // Initialize GLTF loader with DRACO
       const loader = new GLTFLoader();
       loader.setDRACOLoader(dracoLoader);
       
-      const modelPath = `/static/classroom/classroom_${classroomModel}.glb`;
+      const modelPath = `/classroom/classroom_${classroomModel}.glb`;
       console.log("Attempting to load model from:", modelPath);
       // Remove existing classroom if present
       if (classroom && scene) {
@@ -297,7 +297,7 @@
   // Preload classroom models
   function preloadModel(path: string) {
     const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath('/static/draco/');
+    dracoLoader.setDecoderPath('/draco/');
     
     const loader = new GLTFLoader();
     loader.setDRACOLoader(dracoLoader);
@@ -316,6 +316,6 @@
   }
   
   // Preload both classroom models
-  preloadModel('/static/classroom/classroom_default.glb');
-  preloadModel('/static/classroom/classroom_alternative.glb');
+  preloadModel('/classroom/classroom_default.glb');
+  preloadModel('/classroom/classroom_alternative.glb');
 </script> 

--- a/ui/src/lib/components/classroom/ClassroomBackground.svelte
+++ b/ui/src/lib/components/classroom/ClassroomBackground.svelte
@@ -1,321 +1,303 @@
+<script context="module" lang="ts">
+	// Preload classroom models
+	function preloadModel(path: string) {
+		const dracoLoader = new DRACOLoader();
+		dracoLoader.setDecoderPath('/draco/');
+
+		const loader = new GLTFLoader();
+		loader.setDRACOLoader(dracoLoader);
+
+		loader.load(
+			path,
+			() => console.log(`Preloaded: ${path}`),
+			(xhr) => {
+				const percentComplete = Math.round((xhr.loaded / (xhr.total || 1)) * 100);
+				if (percentComplete % 25 === 0) {
+					console.log(`Preloading ${path}: ${percentComplete}%`);
+				}
+			},
+			(error) => console.error(`Error preloading ${path}:`, error)
+		);
+	}
+
+	// Preload both classroom models
+	preloadModel('/classroom/classroom_default.glb');
+	preloadModel('/classroom/classroom_alternative.glb');
+</script>
+
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import * as THREE from 'three';
-  import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-  import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
-  import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer.js';
-  import BoardText from './BoardText.svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import * as THREE from 'three';
+	import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+	import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+	import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer.js';
+	import BoardText from './BoardText.svelte';
 	import { Container } from 'postcss';
 
-  // Props
-  export let classroomModel: 'default' | 'alternative' = 'default';
-  export let scene: THREE.Scene | null = null;
-  export let camera: THREE.PerspectiveCamera | null = null;
-  export let boardMessage: string = "";
-  export let customBoardPosition: { x: number, y: number, z: number } | null = null;
+	// Props
+	export let classroomModel: 'default' | 'alternative' = 'default';
+	export let scene: THREE.Scene | null = null;
+	export let camera: THREE.PerspectiveCamera | null = null;
+	export let boardMessage: string = '';
+	export let customBoardPosition: { x: number; y: number; z: number } | null = null;
 
-  // Variables
-  let classroom: THREE.Group | null = null;
-  let cssRenderer: CSS3DRenderer | null = null;
-  let container: HTMLElement;
-  
-  // Constants for positioning the classroom
-  const classroomPositions = {
-    default: {
-      position: [0.15, -0.75, -0.7], // Adjusted to match the image view
-      rotation: [0, 0, 0],
-      scale: 1.3 // Slightly larger scale
-    },
-    alternative: {
-      position: [0.15, -0.75, -0.7], // Adjusted to match the image view
-      rotation: [0, -Math.PI/8, 0], // Slight angle for better view
-      scale: 0.6 // Larger scale
-    }
-  };
-  
-  // Camera positions that simulate a student sitting at a desk in the first row
-  const cameraPositions = {
-    default: {
-      position: [0, 1.15, 2.6],   // Raised slightly and pushed back for desk to appear
-      lookAt: [0, 1.4, 0]         // Slight upward tilt to center teacher/board
-    },
-    alternative: {
-      position: [0.4, 1.1, 2.3],   // Slightly off-center to the right (like right-side desk)
-      lookAt: [0, 1.4, 0]
-    }
-  };
+	// Variables
+	let classroom: THREE.Group | null = null;
+	let cssRenderer: CSS3DRenderer | null = null;
+	let container: HTMLElement;
 
-  onMount(() => {
-    if (scene && container) {
-      // Initialize CSS3D renderer for HTML content
-      cssRenderer = new CSS3DRenderer();
-      cssRenderer.setSize(window.innerWidth, window.innerHeight);
-      cssRenderer.domElement.style.position = 'absolute';
-      cssRenderer.domElement.style.top = '0';
-      cssRenderer.domElement.style.left = '0';
-      cssRenderer.domElement.style.pointerEvents = 'none';
-      cssRenderer.domElement.style.zIndex = '10'; // Increased z-index to ensure it's on top
-      container.appendChild(cssRenderer.domElement);
-      
-      // Set up window resize handler
-      const handleResize = () => {
-        if (cssRenderer && camera) {
-          cssRenderer.setSize(window.innerWidth, window.innerHeight);
-        }
-      };
-      
-      window.addEventListener('resize', handleResize);
-      
-      // Load classroom without awaiting
-      loadClassroom();
-      
-      // Set up animation loop to render CSS3D content
-      if (camera) {
-        const animate = () => {
-          requestAnimationFrame(animate);
-          if (cssRenderer && scene && camera) {
-            cssRenderer.render(scene, camera);
-          }
-        };
-        animate();
-      }
-      
-      return () => {
-        window.removeEventListener('resize', handleResize);
-      };
-    }
-  });
+	// Constants for positioning the classroom
+	const classroomPositions = {
+		default: {
+			position: [0.15, -0.75, -0.7], // Adjusted to match the image view
+			rotation: [0, 0, 0],
+			scale: 1.3 // Slightly larger scale
+		},
+		alternative: {
+			position: [0.15, -0.75, -0.7], // Adjusted to match the image view
+			rotation: [0, -Math.PI / 8, 0], // Slight angle for better view
+			scale: 0.6 // Larger scale
+		}
+	};
 
-  onDestroy(() => {
-    // Clean up resources
-    if (classroom && scene) {
-      scene.remove(classroom);
-    }
-    if (cssRenderer && container) {
-      container.removeChild(cssRenderer.domElement);
-    }
-  });
+	// Camera positions that simulate a student sitting at a desk in the first row
+	const cameraPositions = {
+		default: {
+			position: [0, 1.15, 2.6], // Raised slightly and pushed back for desk to appear
+			lookAt: [0, 1.4, 0] // Slight upward tilt to center teacher/board
+		},
+		alternative: {
+			position: [0.4, 1.1, 2.3], // Slightly off-center to the right (like right-side desk)
+			lookAt: [0, 1.4, 0]
+		}
+	};
 
-  // Function to set camera to student perspective
-  function setCameraToStudentView() {
-    if (!camera) return;
-    
-    const cameraSettings = cameraPositions[classroomModel];
-    
-    // Position camera like a student sitting at a desk
-    camera.position.set(
-      cameraSettings.position[0],
-      cameraSettings.position[1],
-      cameraSettings.position[2]
-    );
-    
-    // Look toward the board/teacher area
-    camera.lookAt(
-      cameraSettings.lookAt[0],
-      cameraSettings.lookAt[1],
-      cameraSettings.lookAt[2]
-    );
-  }
+	onMount(() => {
+		if (scene && container) {
+			// Initialize CSS3D renderer for HTML content
+			cssRenderer = new CSS3DRenderer();
+			cssRenderer.setSize(window.innerWidth, window.innerHeight);
+			cssRenderer.domElement.style.position = 'absolute';
+			cssRenderer.domElement.style.top = '0';
+			cssRenderer.domElement.style.left = '0';
+			cssRenderer.domElement.style.pointerEvents = 'none';
+			cssRenderer.domElement.style.zIndex = '10'; // Increased z-index to ensure it's on top
+			container.appendChild(cssRenderer.domElement);
 
-  async function loadClassroom() {
-    if (!scene) return;
+			// Set up window resize handler
+			const handleResize = () => {
+				if (cssRenderer && camera) {
+					cssRenderer.setSize(window.innerWidth, window.innerHeight);
+				}
+			};
 
-    try {
-      console.log("Starting classroom load process");
-      
-      // Set up DRACO loader for compressed models
-      const dracoLoader = new DRACOLoader();
-      
-      // Try to use the static draco folders if available, with fallback
-      dracoLoader.setDecoderPath('/draco/');
-      console.log("DracoLoader path set");
-      
-      // Initialize GLTF loader with DRACO
-      const loader = new GLTFLoader();
-      loader.setDRACOLoader(dracoLoader);
-      
-      const modelPath = `/classroom/classroom_${classroomModel}.glb`;
-      console.log("Attempting to load model from:", modelPath);
-      // Remove existing classroom if present
-      if (classroom && scene) {
-        scene.remove(classroom);
-        classroom = null;
-      }
-            // Add a placeholder board (colored plane) until the model loads
-            const boardGeometry = new THREE.PlaneGeometry(3, 1.5);
-      const boardMaterial = new THREE.MeshBasicMaterial({ 
-        color: 0x1a5e1a, 
-        side: THREE.DoubleSide 
-      });
-      const tempBoard = new THREE.Mesh(boardGeometry, boardMaterial);
-      const boardPos = getBoardPosition();
-      tempBoard.position.set(boardPos.x, boardPos.y, boardPos.z);
-      scene.add(tempBoard);
+			window.addEventListener('resize', handleResize);
 
-      const gltf = await new Promise<any>((resolve, reject) => {
-        loader.load(
-          modelPath,
-          (gltf) => {
-            scene.remove(tempBoard);
-            resolve(gltf);
-          },
-          (xhr) => {
-            console.log(`Classroom loading: ${(xhr.loaded / (xhr.total || 1)) * 100}% loaded`);
-          },
-          (error) => {
-            console.error('Error loading classroom model:', error);
-            reject(error);
-          }
-        );
-      });
+			// Load classroom without awaiting
+			loadClassroom();
 
-      classroom = gltf.scene;
-      
-      // Apply position, rotation and scale based on classroom type
-      const settings = classroomPositions[classroomModel];
-      
-      // Set position
-      if (classroom) {
-        classroom.position.set(
-          settings.position[0], 
-          settings.position[1], 
-          settings.position[2]
-        );
-        
-        // Set rotation
-        classroom.rotation.set(
-          settings.rotation[0], 
-          settings.rotation[1], 
-          settings.rotation[2]
-        );
-        
-        // Set scale - uniform scale for all axes
-        classroom.scale.set(
-          settings.scale,
-          settings.scale,
-          settings.scale
-        );
-        
-        // Add to scene
-        scene.add(classroom);
-        console.log('Classroom added to scene successfully');
-      }
-      
-      // Set camera to student view
-      setCameraToStudentView();
-    } catch (error) {
-      console.error('Failed to load classroom model:', error);
-      
-      // Add a fallback classroom environment - just a green board and floor
-      const boardGeometry = new THREE.PlaneGeometry(3, 1.5);
-      const boardMaterial = new THREE.MeshBasicMaterial({ 
-        color: 0x1a5e1a, 
-        side: THREE.DoubleSide 
-      });
-      const board = new THREE.Mesh(boardGeometry, boardMaterial);
-      const boardPos = getBoardPosition();
-      board.position.set(boardPos.x, boardPos.y, boardPos.z);
-      
-      const floorGeometry = new THREE.PlaneGeometry(10, 10);
-      const floorMaterial = new THREE.MeshBasicMaterial({ 
-        color: 0xd2b48c,
-        side: THREE.DoubleSide
-      });
-      const floor = new THREE.Mesh(floorGeometry, floorMaterial);
-      floor.rotation.x = Math.PI / 2;
-      floor.position.y = -0.5;
-      
-      classroom = new THREE.Group();
-      classroom.add(board);
-      classroom.add(floor);
-      scene.add(classroom);
-      
-      console.log('Using fallback classroom environment');
-      
-    } finally {
-    }
-  }
+			// Set up animation loop to render CSS3D content
+			if (camera) {
+				const animate = () => {
+					requestAnimationFrame(animate);
+					if (cssRenderer && scene && camera) {
+						cssRenderer.render(scene, camera);
+					}
+				};
+				animate();
+			}
 
-  // Watch for changes to scene or model
-  $: if (scene && classroomModel) {
-    loadClassroom();
-  }
-  
-  // Export function to get board position for avatar placement
-  export function getBoardPosition() {
-    if (classroomModel === 'default') {
-      // Front-facing classroom with large green board
-      return { 
-        x: 0.3, 
-        y: 1.8, 
-        z: -5 // Moved further back to align with the board surface
-      };
-    } else {
-      // Alternative classroom model
-      return { 
-        x: 3.3, 
-        y: 1.8, 
-        z: -0.4 // Also moved back for side view
-      };
-    }
-  }
-  
-  // Function to detect which classroom model or view is being displayed
-  function detectClassroomModel() {
-    // If we don't have access to the classroom model yet, use default
-    if (!classroom) return 'default';
-    
-    // Try to detect based on classroom properties
-    return classroomModel === 'alternative' ? 'side-view' : 'front-view';
-  }
+			return () => {
+				window.removeEventListener('resize', handleResize);
+			};
+		}
+	});
 
+	onDestroy(() => {
+		// Clean up resources
+		if (classroom && scene) {
+			scene.remove(classroom);
+		}
+		if (cssRenderer && container) {
+			container.removeChild(cssRenderer.domElement);
+		}
+	});
+
+	// Function to set camera to student perspective
+	function setCameraToStudentView() {
+		if (!camera) return;
+
+		const cameraSettings = cameraPositions[classroomModel];
+
+		// Position camera like a student sitting at a desk
+		camera.position.set(
+			cameraSettings.position[0],
+			cameraSettings.position[1],
+			cameraSettings.position[2]
+		);
+
+		// Look toward the board/teacher area
+		camera.lookAt(cameraSettings.lookAt[0], cameraSettings.lookAt[1], cameraSettings.lookAt[2]);
+	}
+
+	async function loadClassroom() {
+		if (!scene) return;
+
+		try {
+			console.log('Starting classroom load process');
+
+			// Set up DRACO loader for compressed models
+			const dracoLoader = new DRACOLoader();
+
+			// Try to use the static draco folders if available, with fallback
+			dracoLoader.setDecoderPath('/draco/');
+			console.log('DracoLoader path set');
+
+			// Initialize GLTF loader with DRACO
+			const loader = new GLTFLoader();
+			loader.setDRACOLoader(dracoLoader);
+
+			const modelPath = `/classroom/classroom_${classroomModel}.glb`;
+			console.log('Attempting to load model from:', modelPath);
+			// Remove existing classroom if present
+			if (classroom && scene) {
+				scene.remove(classroom);
+				classroom = null;
+			}
+			// Add a placeholder board (colored plane) until the model loads
+			const boardGeometry = new THREE.PlaneGeometry(3, 1.5);
+			const boardMaterial = new THREE.MeshBasicMaterial({
+				color: 0x1a5e1a,
+				side: THREE.DoubleSide
+			});
+			const tempBoard = new THREE.Mesh(boardGeometry, boardMaterial);
+			const boardPos = getBoardPosition();
+			tempBoard.position.set(boardPos.x, boardPos.y, boardPos.z);
+			scene.add(tempBoard);
+
+			const gltf = await new Promise<any>((resolve, reject) => {
+				loader.load(
+					modelPath,
+					(gltf) => {
+						scene.remove(tempBoard);
+						resolve(gltf);
+					},
+					(xhr) => {
+						console.log(`Classroom loading: ${(xhr.loaded / (xhr.total || 1)) * 100}% loaded`);
+					},
+					(error) => {
+						console.error('Error loading classroom model:', error);
+						reject(error);
+					}
+				);
+			});
+
+			classroom = gltf.scene;
+
+			// Apply position, rotation and scale based on classroom type
+			const settings = classroomPositions[classroomModel];
+
+			// Set position
+			if (classroom) {
+				classroom.position.set(settings.position[0], settings.position[1], settings.position[2]);
+
+				// Set rotation
+				classroom.rotation.set(settings.rotation[0], settings.rotation[1], settings.rotation[2]);
+
+				// Set scale - uniform scale for all axes
+				classroom.scale.set(settings.scale, settings.scale, settings.scale);
+
+				// Add to scene
+				scene.add(classroom);
+				console.log('Classroom added to scene successfully');
+			}
+
+			// Set camera to student view
+			setCameraToStudentView();
+		} catch (error) {
+			console.error('Failed to load classroom model:', error);
+
+			// Add a fallback classroom environment - just a green board and floor
+			const boardGeometry = new THREE.PlaneGeometry(3, 1.5);
+			const boardMaterial = new THREE.MeshBasicMaterial({
+				color: 0x1a5e1a,
+				side: THREE.DoubleSide
+			});
+			const board = new THREE.Mesh(boardGeometry, boardMaterial);
+			const boardPos = getBoardPosition();
+			board.position.set(boardPos.x, boardPos.y, boardPos.z);
+
+			const floorGeometry = new THREE.PlaneGeometry(10, 10);
+			const floorMaterial = new THREE.MeshBasicMaterial({
+				color: 0xd2b48c,
+				side: THREE.DoubleSide
+			});
+			const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+			floor.rotation.x = Math.PI / 2;
+			floor.position.y = -0.5;
+
+			classroom = new THREE.Group();
+			classroom.add(board);
+			classroom.add(floor);
+			scene.add(classroom);
+
+			console.log('Using fallback classroom environment');
+		} finally {
+		}
+	}
+
+	// Watch for changes to scene or model
+	$: if (scene && classroomModel) {
+		loadClassroom();
+	}
+
+	// Export function to get board position for avatar placement
+	export function getBoardPosition() {
+		if (classroomModel === 'default') {
+			// Front-facing classroom with large green board
+			return {
+				x: 0.3,
+				y: 1.8,
+				z: -5 // Moved further back to align with the board surface
+			};
+		} else {
+			// Alternative classroom model
+			return {
+				x: 3.3,
+				y: 1.8,
+				z: -0.4 // Also moved back for side view
+			};
+		}
+	}
+
+	// Function to detect which classroom model or view is being displayed
+	function detectClassroomModel() {
+		// If we don't have access to the classroom model yet, use default
+		if (!classroom) return 'default';
+
+		// Try to detect based on classroom properties
+		return classroomModel === 'alternative' ? 'side-view' : 'front-view';
+	}
 </script>
 
 <div bind:this={container} class="classroom-container">
-  <!-- The 3D scene will be rendered here -->
+	<!-- The 3D scene will be rendered here -->
 </div>
 
 {#if scene}
-  <BoardText 
-    {scene} 
-    {camera}
-    message={boardMessage} 
-    position={getBoardPosition()} 
-    viewType={classroomModel === 'default' ? 'front-view' : 'side-view'}
-  />
+	<BoardText
+		{scene}
+		{camera}
+		message={boardMessage}
+		position={getBoardPosition()}
+		viewType={classroomModel === 'default' ? 'front-view' : 'side-view'}
+	/>
 {/if}
 
 <style>
-  .classroom-container {
-    position: relative;
-    width: 100%;
-    height: 100%;
-  }
+	.classroom-container {
+		position: relative;
+		width: 100%;
+		height: 100%;
+	}
 </style>
-
-<script context="module" lang="ts">
-  // Preload classroom models
-  function preloadModel(path: string) {
-    const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath('/draco/');
-    
-    const loader = new GLTFLoader();
-    loader.setDRACOLoader(dracoLoader);
-    
-    loader.load(
-      path,
-      () => console.log(`Preloaded: ${path}`),
-      (xhr) => {
-        const percentComplete = Math.round((xhr.loaded / (xhr.total || 1)) * 100);
-        if (percentComplete % 25 === 0) {
-          console.log(`Preloading ${path}: ${percentComplete}%`);
-        }
-      },
-      (error) => console.error(`Error preloading ${path}:`, error)
-    );
-  }
-  
-  // Preload both classroom models
-  preloadModel('/classroom/classroom_default.glb');
-  preloadModel('/classroom/classroom_alternative.glb');
-</script> 


### PR DESCRIPTION
## Summary

The classroom background and student avatar failed to render. The 3D loaders
threw:

`ClassroomBackground.svelte:166 Error loading classroom model:
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`


### Root cause

The GLTF/DRACO/avatar assets were requested under `/static/...`, but in this app
the `ui/static/` directory is served from the **root** (`ui/static/X` → `/X`,
the same convention already used by `/images/background.jpeg`). So URLs like
`/static/classroom/classroom_default.glb` 404'd and returned the SPA
`index.html`. The loaders then tried to `JSON.parse` that HTML, producing the
`Unexpected token '<'` error and falling back to the empty placeholder scene.

## Changes

- `ui/src/lib/components/classroom/ClassroomBackground.svelte`
  - `/static/draco/` → `/draco/`
  - `/static/classroom/` → `/classroom/`
- `ui/src/lib/components/chat/AvatarChat.svelte`
  - `/static/avatar/` → `/avatar/` (avatar model + all 27 GLB animation paths)

No file moves — assets already live at `ui/static/{classroom,draco,avatar}/`;
only the request URLs were wrong.

## Testing

Rebuilt the image and verified against the running container (`:8080`):

- Served JS bundle contains **0** remaining `/static/{classroom,draco,avatar}` references.
- All assets now return real binary content instead of the HTML fallback:
  - `/classroom/classroom_default.glb` → `200 model/gltf-binary`
  - `/draco/draco_decoder.wasm` → `200 application/wasm`
  - `/avatar/The Mentor.glb`, idle/expression GLBs → `200 model/gltf-binary`

Classroom background and avatar render correctly after a hard refresh.

## Notes

- `AvatarOverlay.svelte` has a similar broken path (`backend/avatar/...`) but the
  component is unused (not imported anywhere), so it was left unchanged.
