### PR TITLE
 fix: make PATCH /api/v1/supports/{id} a true partial update

### DIFF
--- a/gateway/http/routers/supports.py
+++ b/gateway/http/routers/supports.py
@@ -45,6 +45,25 @@ class SupportCreateRequest(BaseModel):
     chat_id: Optional[str] = None
 
 
+class SupportUpdateRequest(BaseModel):
+    title: Optional[str] = None
+    short_description: Optional[str] = None
+    subject: Optional[str] = None
+    custom_subject: Optional[str] = None
+    course_id: Optional[str] = None
+    learning_objective: Optional[str] = None
+    learning_type: Optional[str] = None
+    level: Optional[str] = None
+    content_language: Optional[str] = None
+    estimated_duration: Optional[str] = None
+    access_type: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    avatar_id: Optional[str] = None
+    chat_id: Optional[str] = None
+
+
 class SupportFileInfo(BaseModel):
     id: str
     filename: str
@@ -231,7 +250,7 @@ async def update_chat_id(
 @router.patch("/{support_id}", response_model=SupportResponse)
 async def update_support(
     support_id: str,
-    data: SupportCreateRequest,
+    data: SupportUpdateRequest,
     current_user: User = Depends(get_current_user),
     svc: SupportsService = Depends(get_supports_service),
 ):
@@ -240,7 +259,7 @@ async def update_support(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Support not found"
         )
-    updated = svc.update(support_id, data.model_dump())
+    updated = svc.update(support_id, data.model_dump(exclude_unset=True))
     return _to_response(updated)
 
 

--- a/learning/supports/service.py
+++ b/learning/supports/service.py
@@ -53,26 +53,14 @@ class SupportsService:
         return self.repo.get_by_user(user_id, status)
 
     def update(self, support_id: str, data: Dict[str, Any]) -> Support:
-        keywords = data.get("keywords")
-        return self.repo.update(
-            support_id,
-            title=data["title"],
-            short_description=data.get("short_description"),
-            subject=data.get("subject"),
-            custom_subject=data.get("custom_subject"),
-            course_id=data.get("course_id"),
-            learning_objective=data.get("learning_objective"),
-            learning_type=data.get("learning_type"),
-            level=data.get("level"),
-            content_language=data.get("content_language"),
-            estimated_duration=data.get("estimated_duration"),
-            access_type=data.get("access_type"),
-            keywords=",".join(keywords) if keywords else None,
-            start_date=data.get("start_date"),
-            end_date=data.get("end_date"),
-            avatar_id=data.get("avatar_id"),
-            updated_at=datetime.utcnow(),
-        )
+        update_fields: Dict[str, Any] = {}
+        for key, value in data.items():
+            if key == "keywords":
+                update_fields["keywords"] = ",".join(value) if value else None
+            else:
+                update_fields[key] = value
+        update_fields["updated_at"] = datetime.utcnow()
+        return self.repo.update(support_id, **update_fields)
 
     def update_chat_id(self, support_id: str, chat_id: str) -> Support:
         return self.repo.update(


### PR DESCRIPTION

## Changelog Entry

### Description
`PATCH /api/v1/supports/{id}` was unintentionally behaving like a full replace (`PUT`) instead of a partial update. Any field omitted from the request body was overwritten with `null` in the database, because the router reused `SupportCreateRequest` (where all optional fields default to `None`) and called `.model_dump()` without `exclude_unset=True`.

### Added
- `SupportUpdateRequest` schema in `gateway/http/routers/supports.py`, with all fields optional (including `title`)

### Changed
- `update_support` router now uses `SupportUpdateRequest` and calls `data.model_dump(exclude_unset=True)`, so only explicitly provided fields are sent to the service layer
- `SupportsService.update()` rewritten to build the update dict dynamically from the fields present in the request, instead of listing every field with `.get(...)`

### Fixed
- `PATCH /api/v1/supports/{id}` no longer erases fields (e.g. `learning_type`, `subject`, `keywords`, etc.) that are not included in the request body

### Breaking Changes
- None — the response shape and existing fully-specified update calls are unaffected; only the (incorrect) field-erasure behavior changes


### Additional Information

Previously, `update_support` reused `SupportCreateRequest` and called `model_dump()` without `exclude_unset`, so any field omitted from the PATCH body was sent as `None` and overwrote the existing value in the database.

- Added `SupportUpdateRequest` with all fields optional
- Used `model_dump(exclude_unset=True)` in the router
- Rewrote `SupportsService.update()` to only update fields present in the request, instead of a fixed list of fields

**Reproduction (before fix):**
1. `POST /api/v1/supports/create` with `learning_type: "exercice"`
2. `PATCH /api/v1/supports/{id}` with only `{"title": "...", "subject": "..."}`
3. Response showed `learning_type: null` — the value was lost

This was caught while writing integration tests for the frontend ↔ backend contract after the v1.0.0 architecture migration (`learning/supports/*`).
