### PR TITLE
fix(auth): move browser sessions to HttpOnly cookies with CSRF origin guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ TUTORAI_BUILD_HASH=dev-build
 OLLAMA_BASE_URL=http://localhost:11434
 
 # CORS Configuration
+# PRODUCTION: set this to your exact deployed origin(s), e.g. https://tutor.example.com
+# The cookie-session CSRF check trusts these origins for cross-checks — a wrong or
+# missing value here will 403 cookie-authenticated POSTs from the real domain.
 CORS_ALLOW_ORIGIN=http://localhost:3000,http://localhost:5173
 
 # OpenAI Configuration
@@ -31,6 +34,9 @@ DATABASE_URL=sqlite:///./var/tutorai.db
 SECRET_KEY=dev-secret-key-change-in-production
 JWT_ALGORITHM=HS256
 JWT_EXPIRATION_HOURS=24
+# Session cookie: set AUTH_COOKIE_SECURE=true in any HTTPS deployment so the
+# browser only sends the auth cookie over TLS. Left false for plain-HTTP local dev.
+AUTH_COOKIE_SECURE=false
 
 # File Upload Configuration
 UPLOAD_DIR=./var/uploads

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,9 @@ Settings are centralized in `config/settings.py` and loaded from `.env` via `pyt
 - `DEBUG`: enables development behavior and allows the dev JWT secret fallback. Production requires `SECRET_KEY`.
 - `GLOBAL_LOG_LEVEL`: controls Uvicorn log level when running `main.py`.
 - `SECRET_KEY`: JWT signing key; required when `DEBUG=false`.
+- `AUTH_COOKIE_SECURE`: adds `Secure` to the HttpOnly session cookie; set `true` on any HTTPS deployment, `false` (default) for plain-HTTP local dev.
 - `DATABASE_URL`: defaults to `sqlite:///./var/tutorai.db`; non-SQLite URLs use SQLAlchemy defaults.
-- `CORS_ALLOW_ORIGIN`: comma-separated origins; `*` is handled through CORS regex.
+- `CORS_ALLOW_ORIGIN`: comma-separated origins; `*` is handled through CORS regex. Also trusted by the cookie-session CSRF check, so in production set it to the real deployed origin(s) or cookie-authenticated POSTs will be rejected.
 - `UPLOAD_DIR`: defaults to `./var/uploads`.
 - `MAX_UPLOAD_SIZE_MB`: integer upload size limit, default `100`.
 - `VECTOR_DB_PATH`: defaults to `./var/vector_db`.

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,16 @@ class Settings:
     JWT_ALGORITHM: str = "HS256"
     JWT_EXPIRATION_HOURS: int = 24
 
+    # Session cookie (HttpOnly) — the browser-facing auth channel. The JWT is
+    # still accepted via Authorization: Bearer for tests, tools, and API clients.
+    AUTH_COOKIE_NAME: str = "token"
+    # Secure requires HTTPS; local dev and LAN testing run plain HTTP, so it is
+    # opt-in via env for deployments behind TLS.
+    AUTH_COOKIE_SECURE: bool = (
+        os.getenv("AUTH_COOKIE_SECURE", "false").lower() == "true"
+    )
+    AUTH_COOKIE_SAMESITE: str = "lax"
+
     # File upload configuration
     UPLOAD_DIR: str = os.getenv("UPLOAD_DIR", "./var/uploads")
     _upload_mb = os.getenv("MAX_UPLOAD_SIZE_MB", "100")

--- a/gateway/http/app.py
+++ b/gateway/http/app.py
@@ -2,6 +2,7 @@
 
 import os
 from contextlib import asynccontextmanager
+from urllib.parse import urlsplit
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -135,25 +136,51 @@ def create_app() -> FastAPI:
         """CSRF guard for cookie-authenticated state changes.
 
         The session cookie is attached by the browser automatically, so a
-        malicious site could otherwise trigger authenticated mutations. On any
-        non-safe method carrying the session cookie, the Origin header must
-        match this host or a configured CORS origin. Bearer-authenticated
-        clients (tests, curl, SDKs) send no cookie and are unaffected;
-        SameSite=Lax on the cookie is the first line of defence — this is the
-        second.
+        malicious site could otherwise trigger authenticated mutations. This is
+        the second line of defence behind SameSite=Lax on the cookie.
+
+        Scope: only requests authenticated *solely* by the cookie. A request
+        also carrying `Authorization: Bearer` is not a CSRF vector (a cross-site
+        page cannot set that header without a CORS preflight we control), so
+        tests/curl/SDKs are unaffected.
+
+        For a cookie-only unsafe request the `Origin` (or `Referer`) MUST be
+        present and match this host or a configured CORS origin — a *missing*
+        origin is rejected too, closing the "no Origin header" bypass. The
+        expected host honours `X-Forwarded-Proto`/`Host` so the same-origin
+        check still works behind a TLS-terminating reverse proxy.
+
+        Auth-establishment endpoints (signin/signup/login) are exempt: they
+        don't act on an existing session, so cookie-CSRF doesn't apply.
         """
-        if request.method not in ("GET", "HEAD", "OPTIONS") and request.cookies.get(
-            settings.AUTH_COOKIE_NAME
+        is_auth_establish = request.url.path.endswith(("/signin", "/signup", "/login"))
+        if (
+            request.method not in ("GET", "HEAD", "OPTIONS")
+            and not is_auth_establish
+            and request.cookies.get(settings.AUTH_COOKIE_NAME)
         ):
-            origin = request.headers.get("origin")
-            if origin:
-                allowed = origin in settings.cors_origins_list or origin == (
-                    f"{request.url.scheme}://{request.url.netloc}"
+            auth = request.headers.get("authorization", "")
+            bearer = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+            has_bearer = bearer not in ("", "null", "undefined")
+            if not has_bearer:
+                origin = request.headers.get("origin")
+                if not origin and (referer := request.headers.get("referer")):
+                    parsed = urlsplit(referer)
+                    origin = f"{parsed.scheme}://{parsed.netloc}"
+                proto = (
+                    request.headers.get("x-forwarded-proto", request.url.scheme)
+                    .split(",")[0]
+                    .strip()
+                )
+                host = request.headers.get("x-forwarded-host", request.url.netloc)
+                same_origin = f"{proto}://{host}"
+                allowed = bool(origin) and (
+                    origin in settings.cors_origins_list or origin == same_origin
                 )
                 if not allowed:
                     return JSONResponse(
                         status_code=403,
-                        content={"detail": "Origin not allowed"},
+                        content={"detail": "Origin check failed"},
                     )
         return await call_next(request)
 

--- a/gateway/http/app.py
+++ b/gateway/http/app.py
@@ -130,6 +130,33 @@ def create_app() -> FastAPI:
             )
         return await call_next(request)
 
+    @app.middleware("http")
+    async def csrf_origin_check(request: Request, call_next):
+        """CSRF guard for cookie-authenticated state changes.
+
+        The session cookie is attached by the browser automatically, so a
+        malicious site could otherwise trigger authenticated mutations. On any
+        non-safe method carrying the session cookie, the Origin header must
+        match this host or a configured CORS origin. Bearer-authenticated
+        clients (tests, curl, SDKs) send no cookie and are unaffected;
+        SameSite=Lax on the cookie is the first line of defence — this is the
+        second.
+        """
+        if request.method not in ("GET", "HEAD", "OPTIONS") and request.cookies.get(
+            settings.AUTH_COOKIE_NAME
+        ):
+            origin = request.headers.get("origin")
+            if origin:
+                allowed = origin in settings.cors_origins_list or origin == (
+                    f"{request.url.scheme}://{request.url.netloc}"
+                )
+                if not allowed:
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": "Origin not allowed"},
+                    )
+        return await call_next(request)
+
     # Health — no version prefix, matches Docker healthcheck and compose
     app.include_router(health.router)
 

--- a/gateway/http/dependencies.py
+++ b/gateway/http/dependencies.py
@@ -1,6 +1,6 @@
 """FastAPI dependency injection — auth guard + service factories."""
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import InvalidTokenError, decode
 from sqlalchemy.orm import Session
@@ -13,20 +13,37 @@ from data.models import User
 from governance.self_regulation.service import SelfRegulationService
 from learning.supports.service import SupportsService
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 # ── Auth guard ────────────────────────────────────────────────────────────────
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
     db: Session = Depends(get_db),
 ) -> User:
-    """Decode JWT and return the authenticated user."""
+    """Decode the JWT and return the authenticated user.
+
+    An explicit `Authorization: Bearer` token wins (tests, tools, API clients
+    state exactly who they are); otherwise the HttpOnly session cookie — the
+    browser channel — is used. Legacy UI code that still sends the literal
+    strings "null"/"undefined" (from a now-empty localStorage) is treated as
+    sending nothing, so those requests fall through to the cookie.
+    """
+    bearer = credentials.credentials if credentials else None
+    if bearer in ("null", "undefined", ""):
+        bearer = None
+    token = bearer or request.cookies.get(settings.AUTH_COOKIE_NAME)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
     try:
         payload = decode(
-            credentials.credentials,
+            token,
             settings.JWT_SECRET_KEY,
             algorithms=[settings.JWT_ALGORITHM],
         )

--- a/gateway/http/routers/auth.py
+++ b/gateway/http/routers/auth.py
@@ -55,6 +55,25 @@ def _create_token(user_id: str) -> str:
     )
 
 
+def _set_auth_cookie(response: Response, token: str) -> None:
+    """Attach the session JWT as an HttpOnly cookie — the browser auth channel.
+
+    HttpOnly keeps the token out of reach of any script running on the page
+    (XSS cannot exfiltrate it); SameSite=Lax stops the browser attaching it to
+    cross-site requests. `Secure` is enabled via AUTH_COOKIE_SECURE on TLS
+    deployments.
+    """
+    response.set_cookie(
+        key=settings.AUTH_COOKIE_NAME,
+        value=token,
+        max_age=settings.JWT_EXPIRATION_HOURS * 3600,
+        httponly=True,
+        secure=settings.AUTH_COOKIE_SECURE,
+        samesite=settings.AUTH_COOKIE_SAMESITE,
+        path="/",
+    )
+
+
 def _user_payload(token: str, user: User) -> dict:
     return {
         "token": token,
@@ -82,9 +101,10 @@ async def get_session_user(current_user: User = Depends(get_current_user)):
 @router.post("/signin")
 async def sign_in(
     request: SignInRequest,
+    response: Response,
     svc: AccountService = Depends(get_account_service),
 ):
-    """Sign in — UI calls /auths/signin."""
+    """Sign in — UI calls /auths/signin. Sets the HttpOnly session cookie."""
     user = svc.authenticate(request.email, request.password)
     if not user:
         raise HTTPException(
@@ -94,24 +114,28 @@ async def sign_in(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Account inactive"
         )
-    return _user_payload(_create_token(user.id), user)
+    token = _create_token(user.id)
+    _set_auth_cookie(response, token)
+    return _user_payload(token, user)
 
 
 @router.post("/login")
 async def login(
     request: SignInRequest,
+    response: Response,
     svc: AccountService = Depends(get_account_service),
 ):
     """Login alias — kept for internal/tool use."""
-    return await sign_in(request, svc)
+    return await sign_in(request, response, svc)
 
 
 @router.post("/signup")
 async def signup(
     request: SignUpRequest,
+    response: Response,
     svc: AccountService = Depends(get_account_service),
 ):
-    """Sign up — first user becomes admin."""
+    """Sign up — first user becomes admin. Sets the HttpOnly session cookie."""
     is_admin = svc.count_users() == 0
     try:
         user = svc.create_user(
@@ -124,13 +148,29 @@ async def signup(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    return _user_payload(_create_token(user.id), user)
+    token = _create_token(user.id)
+    _set_auth_cookie(response, token)
+    return _user_payload(token, user)
+
+
+@router.post("/cookie")
+async def establish_cookie_session(
+    response: Response,
+    current_user: User = Depends(get_current_user),
+):
+    """Exchange a Bearer-authenticated request for an HttpOnly cookie session.
+
+    Used by flows that receive a token out-of-band (e.g. OAuth URL fragments)
+    so the browser can continue with cookie auth instead of storing the token.
+    """
+    _set_auth_cookie(response, _create_token(current_user.id))
+    return {"status": "success"}
 
 
 @router.get("/signout")
 async def sign_out(response: Response):
-    """Sign out — clears session cookie."""
-    response.delete_cookie("token")
+    """Sign out — clears the session cookie."""
+    response.delete_cookie(settings.AUTH_COOKIE_NAME, path="/")
     return {"status": "success"}
 
 

--- a/gateway/realtime/socket.py
+++ b/gateway/realtime/socket.py
@@ -1,16 +1,18 @@
 """Socket.IO ASGI sub-application mounted at /realtime.
 
 The client connects to TUTOR_BASE_URL with path='/realtime/socket.io'.
-Authentication is via JWT token passed as `token` query parameter or
-Authorization header.
+Authentication is via the HttpOnly session cookie (browser flow) or a JWT
+passed in the Socket.IO auth payload / `token` query parameter (tools, tests).
 """
 
 import logging
 import time
+from http.cookies import SimpleCookie
 from typing import Any
 
 import socketio
 
+from config import settings
 from gateway.http.dependencies import decode_jwt_token
 
 log = logging.getLogger(__name__)
@@ -58,16 +60,37 @@ async def _broadcast_usage():
     log.debug("Broadcast usage: %s", models)
 
 
+def _token_from_cookie(environ: dict) -> str | None:
+    """Extract the session JWT from the HTTP cookie header of the handshake."""
+    raw = environ.get("HTTP_COOKIE")
+    if not raw:
+        return None
+    cookie = SimpleCookie()
+    try:
+        cookie.load(raw)
+    except Exception:
+        return None
+    morsel = cookie.get(settings.AUTH_COOKIE_NAME)
+    return morsel.value if morsel else None
+
+
 @sio.event
 async def connect(sid: str, environ: dict, auth: dict | None = None):
     """Authenticate on connect. Disconnect immediately if no valid token."""
     token = None
 
-    # 1. Try auth dict (from Socket.IO client auth option)
+    # 1. Try auth dict (from Socket.IO client auth option). Older clients may
+    #    send the literal strings "null"/"undefined" when nothing is stored.
     if auth and isinstance(auth, dict):
         token = auth.get("token")
+        if token in ("null", "undefined", ""):
+            token = None
 
-    # 2. Fall back to query string: ?token=<jwt>
+    # 2. HttpOnly session cookie — the browser flow (JS never sees the token).
+    if not token:
+        token = _token_from_cookie(environ)
+
+    # 3. Fall back to query string: ?token=<jwt>
     if not token:
         qs = environ.get("QUERY_STRING", "")
         for part in qs.split("&"):

--- a/tests/test_cookie_auth.py
+++ b/tests/test_cookie_auth.py
@@ -2,9 +2,9 @@
 """HttpOnly cookie sessions — the browser auth channel.
 
 Signin/signup set an HttpOnly, SameSite=Lax session cookie; `get_current_user`
-reads the cookie first and falls back to `Authorization: Bearer` (tests, tools).
-A CSRF origin check guards cookie-authenticated mutations, and the Socket.IO
-handshake accepts the cookie as well.
+prefers an explicit `Authorization: Bearer` token (tests, tools) and otherwise
+authenticates via the cookie. A CSRF origin check guards *cookie-only*
+mutations, and the Socket.IO handshake accepts the cookie as well.
 """
 
 from config import settings
@@ -12,6 +12,10 @@ from gateway.realtime.socket import _token_from_cookie
 
 
 def _signup(client, email="cookie@t.com", name="Cookie", password="pass1234!"):
+    # Signup happens while logged out — clear any prior session cookie so the
+    # request is anonymous (mirrors a browser, and avoids the cookie-only CSRF
+    # guard firing on a bodyless-origin test request).
+    client.cookies.clear()
     r = client.post(
         "/auths/signup", json={"email": email, "name": name, "password": password}
     )
@@ -114,38 +118,55 @@ def test_bearer_to_cookie_exchange(client):
 # ── CSRF origin check ────────────────────────────────────────────────────────
 
 
-def test_csrf_blocks_cookie_mutation_from_foreign_origin(client):
-    _signup(client)
-    r = client.post(
+def _pw_update(client, **headers):
+    return client.post(
         "/api/v1/auths/update/password",
         json={"password": "pass1234!", "new_password": "other5678!"},
-        headers={"Origin": "https://evil.example"},
+        headers=headers,
     )
+
+
+def test_csrf_blocks_cookie_mutation_from_foreign_origin(client):
+    _signup(client)
+    r = _pw_update(client, Origin="https://evil.example")
     assert r.status_code == 403
-    assert r.json()["detail"] == "Origin not allowed"
+    assert r.json()["detail"] == "Origin check failed"
+
+
+def test_csrf_blocks_cookie_mutation_with_missing_origin(client):
+    """A cookie-only unsafe request with NO Origin/Referer is rejected too —
+    closes the "no Origin header" bypass."""
+    _signup(client)
+    r = _pw_update(client)
+    assert r.status_code == 403
 
 
 def test_csrf_allows_configured_origin(client):
     _signup(client)
-    r = client.post(
-        "/api/v1/auths/update/password",
-        json={"password": "pass1234!", "new_password": "other5678!"},
-        headers={"Origin": "http://localhost:5173"},  # default CORS origin
+    r = _pw_update(client, Origin="http://localhost:5173")  # default CORS origin
+    assert r.status_code == 200, r.text
+
+
+def test_csrf_allows_same_origin_via_forwarded_proto(client):
+    """Behind a TLS-terminating proxy the app sees http internally; the check
+    must honour X-Forwarded-Proto/Host so the real https origin matches."""
+    _signup(client)
+    r = _pw_update(
+        client,
+        Origin="https://tutor.example.com",
+        **{"X-Forwarded-Proto": "https", "X-Forwarded-Host": "tutor.example.com"},
     )
     assert r.status_code == 200, r.text
 
 
 def test_csrf_does_not_affect_bearer_clients(client):
-    """No cookie → no CSRF exposure → foreign Origin is fine for API clients."""
-    data = _signup(client)
-    client.cookies.clear()
-    r = client.post(
-        "/api/v1/auths/update/password",
-        json={"password": "pass1234!", "new_password": "other5678!"},
-        headers={
-            "Authorization": f"Bearer {data['token']}",
-            "Origin": "https://anywhere.example",
-        },
+    """A bearer token isn't a CSRF vector — foreign Origin is fine for API clients,
+    even when a cookie is also present."""
+    data = _signup(client)  # client keeps the cookie too
+    r = _pw_update(
+        client,
+        Authorization=f"Bearer {data['token']}",
+        Origin="https://anywhere.example",
     )
     assert r.status_code == 200, r.text
 

--- a/tests/test_cookie_auth.py
+++ b/tests/test_cookie_auth.py
@@ -1,0 +1,166 @@
+# tests/test_cookie_auth.py
+"""HttpOnly cookie sessions — the browser auth channel.
+
+Signin/signup set an HttpOnly, SameSite=Lax session cookie; `get_current_user`
+reads the cookie first and falls back to `Authorization: Bearer` (tests, tools).
+A CSRF origin check guards cookie-authenticated mutations, and the Socket.IO
+handshake accepts the cookie as well.
+"""
+
+from config import settings
+from gateway.realtime.socket import _token_from_cookie
+
+
+def _signup(client, email="cookie@t.com", name="Cookie", password="pass1234!"):
+    r = client.post(
+        "/auths/signup", json={"email": email, "name": name, "password": password}
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ── cookie issuing ────────────────────────────────────────────────────────────
+
+
+def test_signup_and_signin_set_httponly_cookie(client):
+    r = client.post(
+        "/auths/signup",
+        json={"email": "a@t.com", "name": "A", "password": "pass1234!"},
+    )
+    raw = r.headers.get("set-cookie", "")
+    assert f"{settings.AUTH_COOKIE_NAME}=" in raw
+    assert "HttpOnly" in raw
+    assert "SameSite=lax" in raw
+    assert "Path=/" in raw
+
+    client.cookies.clear()
+    r = client.post(
+        "/api/v1/auths/signin", json={"email": "a@t.com", "password": "pass1234!"}
+    )
+    assert r.status_code == 200, r.text
+    raw = r.headers.get("set-cookie", "")
+    assert f"{settings.AUTH_COOKIE_NAME}=" in raw and "HttpOnly" in raw
+
+
+def test_cookie_authenticates_without_bearer_header(client):
+    _signup(client)  # TestClient persists the Set-Cookie automatically
+    r = client.get("/api/v1/auths/")  # no Authorization header at all
+    assert r.status_code == 200, r.text
+    assert r.json()["email"] == "cookie@t.com"
+
+
+def test_signout_clears_cookie_session(client):
+    _signup(client)
+    assert client.get("/api/v1/auths/").status_code == 200
+    r = client.get("/api/v1/auths/signout")
+    assert r.status_code == 200
+    assert client.get("/api/v1/auths/").status_code == 401
+
+
+# ── bearer compatibility ─────────────────────────────────────────────────────
+
+
+def test_bearer_still_works_without_cookie(client):
+    data = _signup(client)
+    client.cookies.clear()
+    r = client.get(
+        "/api/v1/auths/", headers={"Authorization": f"Bearer {data['token']}"}
+    )
+    assert r.status_code == 200
+    assert r.json()["email"] == "cookie@t.com"
+
+
+def test_stale_bearer_falls_through_to_cookie(client):
+    """Older UI code may still send `Authorization: Bearer null` — with a valid
+    cookie session that garbage header must be ignored, not break the request."""
+    _signup(client)
+    r = client.get("/api/v1/auths/", headers={"Authorization": "Bearer null"})
+    assert r.status_code == 200
+
+
+def test_explicit_bearer_wins_over_cookie(client):
+    """A real Bearer token states exactly who the caller is — it must not be
+    silently overridden by whatever session cookie the client happens to hold."""
+    first = _signup(client)
+    _signup(client, email="second@t.com")  # the client's cookie is now SECOND's
+    r = client.get(
+        "/api/v1/auths/", headers={"Authorization": f"Bearer {first['token']}"}
+    )
+    assert r.status_code == 200
+    assert r.json()["email"] == "cookie@t.com"  # the bearer's user, not the cookie's
+    # And without the header, the cookie (second user) authenticates.
+    assert client.get("/api/v1/auths/").json()["email"] == "second@t.com"
+
+
+def test_missing_credentials_is_401(client):
+    client.cookies.clear()
+    assert client.get("/api/v1/auths/").status_code == 401
+
+
+def test_bearer_to_cookie_exchange(client):
+    """The /auths/cookie endpoint turns a bearer-authenticated request (e.g. an
+    OAuth fragment token) into an HttpOnly cookie session."""
+    data = _signup(client)
+    client.cookies.clear()
+    r = client.post(
+        "/api/v1/auths/cookie", headers={"Authorization": f"Bearer {data['token']}"}
+    )
+    assert r.status_code == 200, r.text
+    assert "HttpOnly" in r.headers.get("set-cookie", "")
+    # The exchanged cookie now authenticates on its own.
+    assert client.get("/api/v1/auths/").status_code == 200
+
+
+# ── CSRF origin check ────────────────────────────────────────────────────────
+
+
+def test_csrf_blocks_cookie_mutation_from_foreign_origin(client):
+    _signup(client)
+    r = client.post(
+        "/api/v1/auths/update/password",
+        json={"password": "pass1234!", "new_password": "other5678!"},
+        headers={"Origin": "https://evil.example"},
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Origin not allowed"
+
+
+def test_csrf_allows_configured_origin(client):
+    _signup(client)
+    r = client.post(
+        "/api/v1/auths/update/password",
+        json={"password": "pass1234!", "new_password": "other5678!"},
+        headers={"Origin": "http://localhost:5173"},  # default CORS origin
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_csrf_does_not_affect_bearer_clients(client):
+    """No cookie → no CSRF exposure → foreign Origin is fine for API clients."""
+    data = _signup(client)
+    client.cookies.clear()
+    r = client.post(
+        "/api/v1/auths/update/password",
+        json={"password": "pass1234!", "new_password": "other5678!"},
+        headers={
+            "Authorization": f"Bearer {data['token']}",
+            "Origin": "https://anywhere.example",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_csrf_ignores_safe_methods(client):
+    _signup(client)
+    r = client.get("/api/v1/auths/", headers={"Origin": "https://evil.example"})
+    assert r.status_code == 200
+
+
+# ── realtime handshake helper ────────────────────────────────────────────────
+
+
+def test_socket_token_from_cookie_header():
+    environ = {"HTTP_COOKIE": f"other=1; {settings.AUTH_COOKIE_NAME}=jwt-here; x=2"}
+    assert _token_from_cookie(environ) == "jwt-here"
+    assert _token_from_cookie({"HTTP_COOKIE": "other=1"}) is None
+    assert _token_from_cookie({}) is None

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -71,7 +71,10 @@ class TestFilesApiV1:
         """Content endpoint requires authentication — no anonymous access."""
         token = _signup(client, "noauth@test.com")
         file_id = _upload(client, token).json()["id"]
-        assert client.get(f"/api/v1/files/{file_id}/content").status_code == 403
+        # Drop the cookie session the signup established — this request must be
+        # truly anonymous (no cookie, no bearer).
+        client.cookies.clear()
+        assert client.get(f"/api/v1/files/{file_id}/content").status_code == 401
 
     def test_update_file_content(self, client):
         """POST /api/v1/files/{id}/data/content/update  ← updateFileDataContentById() in files/index.ts:124"""

--- a/ui/src/lib/apis/auths/index.ts
+++ b/ui/src/lib/apis/auths/index.ts
@@ -82,15 +82,18 @@ export const updateAdminConfig = async (token: string, body: object) => {
 	return res;
 };
 
-export const getSessionUser = async (token: string) => {
+export const getSessionUser = async (token?: string) => {
 	let error = null;
+
+	// Only send the Authorization header when we actually have a token; otherwise
+	// the request authenticates via the HttpOnly session cookie. Sending an empty
+	// `Bearer ` header would be ambiguous for the server to parse.
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	if (token) headers.Authorization = `Bearer ${token}`;
 
 	const res = await fetch(`${TUTOR_API_BASE_URL}/auths/`, {
 		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		},
+		headers,
 		credentials: 'include'
 	})
 		.then(async (res) => {
@@ -370,7 +373,9 @@ export const establishCookieSession = async (token: string) => {
 		})
 		.catch((err) => {
 			console.log(err);
-			error = err.detail;
+			// Surface a message even for non-JSON failures (network errors, thrown
+			// strings) so a failed cookie exchange can't be silently ignored.
+			error = err?.detail ?? 'Could not establish a session';
 			return null;
 		});
 

--- a/ui/src/lib/apis/auths/index.ts
+++ b/ui/src/lib/apis/auths/index.ts
@@ -353,6 +353,34 @@ export const userSignUp = async (
 	return res;
 };
 
+export const establishCookieSession = async (token: string) => {
+	let error = null;
+
+	const res = await fetch(`${TUTOR_API_BASE_URL}/auths/cookie`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		credentials: 'include'
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.log(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const userSignOut = async () => {
 	let error = null;
 

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -3,14 +3,17 @@ import { browser, dev } from '$app/environment';
 
 export const APP_NAME = 'Open TutorAI';
 
-// Backend server for API calls
-export const TUTOR_HOSTNAME = browser ? (dev ? `${location.hostname}:8080` : ``) : '';
+// Backend API calls are always same-origin: in production FastAPI serves the
+// SPA, and in dev the Vite proxy forwards /api, /auths and /realtime to the
+// backend. Same-origin means the HttpOnly session cookie rides along on every
+// request without per-fetch `credentials` handling.
+export const TUTOR_HOSTNAME = '';
 
 // Frontend server for static assets (Vite dev server)
 export const TUTOR_FRONT_HOSTNAME = browser ? (dev ? `${location.hostname}:5173` : ``) : '';
 export const TUTOR_FRONT_URL = browser ? (dev ? `http://${TUTOR_FRONT_HOSTNAME}` : ``) : ``;
 
-export const TUTOR_BASE_URL = browser ? (dev ? `http://${TUTOR_HOSTNAME}` : ``) : ``;
+export const TUTOR_BASE_URL = '';
 export const TUTOR_API_BASE_URL = `${TUTOR_BASE_URL}/api/v1`;
 
 export const OLLAMA_API_BASE_URL = `${TUTOR_API_BASE_URL}/providers/ollama`;

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -63,7 +63,9 @@
 			randomizationFactor: 0.5,
 			path: '/realtime/socket.io',
 			transports: enableWebsocket ? ['websocket'] : ['polling', 'websocket'],
-			auth: { token: localStorage.token }
+			// The handshake is authenticated by the HttpOnly session cookie, which
+			// the browser attaches automatically on this same-origin connection.
+			withCredentials: true
 		});
 
 		await socket.set(_socket);
@@ -483,43 +485,37 @@
 			if ($config) {
 				await setupSocket($config.features?.enable_websocket ?? true);
 
-				if (localStorage.token) {
-					// Get Session User Info
-					const sessionUser = await getSessionUser(localStorage.token).catch((error) => {
-						toast.error(`${error}`);
-						return null;
-					});
+				// Probe the session — the HttpOnly cookie (sent automatically) decides
+				// whether we're signed in; nothing is read from localStorage.
+				const sessionUser = await getSessionUser('').catch(() => null);
 
-					if (sessionUser) {
-						// Save Session User to Store
-						$socket.emit('user-join', { auth: { token: sessionUser.token } });
+				if (sessionUser) {
+					// Save Session User to Store
+					$socket.emit('user-join', { auth: { token: sessionUser.token } });
 
-						$socket?.on('chat-events', chatEventHandler);
-						$socket?.on('channel-events', channelEventHandler);
+					$socket?.on('chat-events', chatEventHandler);
+					$socket?.on('channel-events', channelEventHandler);
 
-						await user.set(sessionUser);
-						await config.set(await getBackendConfig());
+					await user.set(sessionUser);
+					await config.set(await getBackendConfig());
 
-						// Role-based redirection
-						if ($page.url.pathname === '/') {
-							if (sessionUser.role === 'admin') {
-								await goto('/');
-							} else if (sessionUser.role === 'user') {
-								await goto('/student/dashboard');
-							} else if (sessionUser.role === 'parent') {
-								await goto('/parent');
-							} else if (sessionUser.role === 'teacher') {
-								await goto('/teacher');
-							}
+					// Role-based redirection
+					if ($page.url.pathname === '/') {
+						if (sessionUser.role === 'admin') {
+							await goto('/');
+						} else if (sessionUser.role === 'user') {
+							await goto('/student/dashboard');
+						} else if (sessionUser.role === 'parent') {
+							await goto('/parent');
+						} else if (sessionUser.role === 'teacher') {
+							await goto('/teacher');
 						}
-					} else {
-						// Redirect Invalid Session User to /auth Page
-						localStorage.removeItem('token');
-						await goto('/auth');
 					}
 				} else {
-					// Don't redirect if we're already on the auth page
-					// Needed because we pass in tokens from OAuth logins via URL fragments
+					// No valid cookie session. Clear any legacy token left from the
+					// pre-cookie era; don't redirect while on /auth itself (OAuth
+					// fragments land there).
+					localStorage.removeItem('token');
 					if ($page.url.pathname !== '/auth') {
 						await goto('/auth');
 					}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -487,12 +487,11 @@
 
 				// Probe the session — the HttpOnly cookie (sent automatically) decides
 				// whether we're signed in; nothing is read from localStorage.
-				const sessionUser = await getSessionUser('').catch(() => null);
+				const sessionUser = await getSessionUser().catch(() => null);
 
 				if (sessionUser) {
-					// Save Session User to Store
-					$socket.emit('user-join', { auth: { token: sessionUser.token } });
-
+					// The socket is already authenticated by the cookie in connect(),
+					// so no user-join token emit is needed here.
 					$socket?.on('chat-events', chatEventHandler);
 					$socket?.on('channel-events', channelEventHandler);
 

--- a/ui/src/routes/auth/+page.svelte
+++ b/ui/src/routes/auth/+page.svelte
@@ -61,7 +61,11 @@
 			// signin/signup — nothing is persisted where page scripts can read it.
 
 			if ($socket) {
-				$socket.emit('user-join', { auth: { token: sessionUser.token } });
+				// The socket first connected on /auth before we were logged in (an
+				// anonymous, rejected handshake). Reconnect so the handshake re-runs
+				// carrying the freshly-set session cookie — no token passed to JS.
+				$socket.disconnect();
+				$socket.connect();
 			}
 			await user.set(sessionUser);
 			await config.set(await getBackendConfig());
@@ -164,8 +168,14 @@
 			return;
 		}
 		// Exchange the fragment token for an HttpOnly cookie session instead of
-		// persisting it anywhere page scripts could read it.
-		await establishCookieSession(token).catch(() => {});
+		// persisting it anywhere page scripts could read it. If this fails there is
+		// no session — surface it and stop rather than appearing logged in.
+		try {
+			await establishCookieSession(token);
+		} catch (err) {
+			toast.error(`${err}`);
+			return;
+		}
 		await setSessionUser(sessionUser);
 	};
 

--- a/ui/src/routes/auth/+page.svelte
+++ b/ui/src/routes/auth/+page.svelte
@@ -13,7 +13,8 @@
 		getSessionUser,
 		userSignIn,
 		userSignUp,
-		getUserCount
+		getUserCount,
+		establishCookieSession
 	} from '$lib/apis/auths';
 
 	import { TUTOR_FRONT_URL, TUTOR_BASE_URL } from '$lib/constants';
@@ -56,9 +57,8 @@
 		if (sessionUser) {
 			console.log('Session user received:', sessionUser);
 			toast.success($i18n.t(`You're now logged in.`));
-			if (sessionUser.token) {
-				localStorage.token = sessionUser.token;
-			}
+			// The session now lives in an HttpOnly cookie set by the backend at
+			// signin/signup — nothing is persisted where page scripts can read it.
 
 			if ($socket) {
 				$socket.emit('user-join', { auth: { token: sessionUser.token } });
@@ -163,7 +163,9 @@
 		if (!sessionUser) {
 			return;
 		}
-		localStorage.token = token;
+		// Exchange the fragment token for an HttpOnly cookie session instead of
+		// persisting it anywhere page scripts could read it.
+		await establishCookieSession(token).catch(() => {});
 		await setSessionUser(sessionUser);
 	};
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -56,24 +56,23 @@ export default defineConfig({
 			usePolling: true
 		},
 		proxy: {
+			// Dev requests are same-origin (relative URLs in constants.ts) and are
+			// proxied to the backend here — that way the HttpOnly session cookie is
+			// first-party and attached automatically, mirroring production where
+			// FastAPI serves the SPA itself. BACKEND_URL overrides the target for
+			// Docker (e.g. http://open-tutor-backend:8080).
 			'/api': {
-				target: 'http://open-tutor-backend:8080',
+				target: process.env.BACKEND_URL ?? 'http://localhost:8080',
 				changeOrigin: true,
-				secure: false,
-				configure: (proxy, _options) => {
-					proxy.on('error', (err, _req, _res) => {
-						console.log('proxy error', err);
-					});
-					proxy.on('proxyReq', (proxyReq, req, _res) => {
-						console.log('Sending Request to the Target:', req.method, req.url);
-					});
-					proxy.on('proxyRes', (proxyRes, req, _res) => {
-						console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
-					});
-				}
+				secure: false
 			},
-			'/ws': {
-				target: 'ws://open-tutor-backend:8080',
+			'/auths': {
+				target: process.env.BACKEND_URL ?? 'http://localhost:8080',
+				changeOrigin: true,
+				secure: false
+			},
+			'/realtime': {
+				target: process.env.BACKEND_URL ?? 'http://localhost:8080',
 				ws: true,
 				changeOrigin: true
 			}


### PR DESCRIPTION
This PR closes the known platform-wide limitation where the session JWT was kept in
`localStorage` — readable by any script running on the page, so a single XSS bug anywhere
in the app could exfiltrate sessions. Browser sessions now live in an **HttpOnly,
SameSite=Lax cookie** that page scripts cannot read, with a **CSRF origin guard** on
cookie-authenticated mutations (the protection that becomes relevant once cookies are the
auth channel).

**How it works**

- **Signin / signup** set the session cookie server-side; **signout** clears it. The SPA
  never persists the token anywhere script-readable.
- **`get_current_user`**: an explicit `Authorization: Bearer` token wins (tests, curl,
  SDKs state exactly who they are); otherwise the cookie authenticates. Legacy
  `Bearer null`/`undefined` headers from pre-cookie UI code fall through to the cookie,
  so nothing breaks during the transition.
- **CSRF**: on any non-safe method carrying the session cookie, the `Origin` header must
  match this host or a configured CORS origin — second line of defence behind
  SameSite=Lax. Bearer-only clients are unaffected.
- **Socket.IO** handshake authenticates via the cookie (auth payload / query token still
  accepted for tools).
- **Same-origin by construction**: production already serves the SPA from FastAPI; dev
  now routes `/api`, `/auths` and `/realtime` through the Vite proxy (`BACKEND_URL` env
  overrides the target for Docker). Because every call is same-origin, the cookie rides
  along automatically — no per-fetch `credentials` churn across the ~290 existing fetch
  calls, and any future fetch is covered by default.
- `POST /auths/cookie` exchanges a bearer token (e.g. OAuth URL fragment) for a cookie
  session.
- `AUTH_COOKIE_SECURE=true` env flag adds the `Secure` attribute for TLS deployments
  (off by default so plain-HTTP local/LAN dev keeps working).

**Compatibility**

- API clients, tests, and tools using `Authorization: Bearer` work unchanged.
- Users signed in before this change simply sign in once more (the old localStorage
  token is ignored and cleaned up).
- The legacy `/ws` proxy entry was removed from Vite config (the backend rejects that
  path by design).

**How to test**

1. `uvicorn main:app --port 8080` + `cd ui && npm run dev`, open http://localhost:5173.
2. Sign in → DevTools → Application → Cookies: `token` cookie marked **HttpOnly** —
   and `localStorage` contains **no token**.
3. In the console: `document.cookie` → the session token is not there (that's the fix).
4. Reload the page → still signed in (cookie session). Sign out → cookie gone,
   redirected to /auth.
5. Realtime still connects (check the Network tab: `/realtime/socket.io` handshake, no
   token in the request payload).
6. Backend suite: `pytest -q` → all green, including the new `tests/test_cookie_auth.py`
   (cookie issuing/auth/signout, bearer compatibility and precedence, bearer→cookie
   exchange, CSRF allow/block/bypass, handshake cookie parsing).

**UI changes**

None visually — auth flow behaves identically; only the storage mechanism changed.

**Breaking changes**

None for the UI or API consumers. Deployments that terminate TLS should set
`AUTH_COOKIE_SECURE=true`.